### PR TITLE
Fix Cygwin compilation and miscellaneous fixes and tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 lighterjson: src/lighterjson.c
-             $(CC) -Ofast -Wall -o lighterjson src/lighterjson.c
+	$(CC) -Ofast -Wall -o lighterjson src/lighterjson.c

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Numbers can be rounded to specific decimal places using the -p switch. Use negat
 
 JSON technically supports numbers of unlimited size, but due to implementation complexity, the supported exponent range is [-9223372036854775807, 9223372036854775807].
 
-Files must be UTF-8. Not all cases of ill-formed files are currently handled. Only works with POSIX systems currently. Make sure to backup before running.
+Files must be UTF-8. Not all cases of ill-formed files are currently handled. Make sure to backup before running.
+
+It depends on standard POSIX headers, so it works best in POSIX-compliant operating systems. However, it can also be built for Windows by using a Cygwin-based toolchain.
 
 ## Author
 Aaron Kaluszka <<megabyte@kontek.net>>


### PR DESCRIPTION
This PR allows the code to be compiled under a Cygwin-based toolchain, namely i686-w64-mingw32-gcc. Moreover, it also removes dependencies on not standard integer types, improves error messages showed by the do_file function, always closes the file descriptors that function opens and fixes some Makefile parsing errors arising from not using TAB. Some printf format specificators were changed in order to be more cross-platform, too.